### PR TITLE
Remove pointer constructors for vector iterators

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include "ips4o.hpp"
 #include "args.hxx"
-#include <endian.h>
 #include <utility>
 #include "mmmultimap.hpp"
 #include "mmmultiset.hpp"

--- a/src/mmmultimap.hpp
+++ b/src/mmmultimap.hpp
@@ -136,6 +136,10 @@ private:
     }
 
 public:
+    
+    // forward declaration for iterator types
+    class iterator;
+    class const_iterator;
 
     // constructor
     map(void) { init(); }
@@ -335,11 +339,10 @@ public:
         //std::cerr << "sorting!" << std::endl;
         mmap_buffer_t buffer;
         open_mmap_buffer(filename.c_str(), &buffer);
-        typename std::vector<std::pair<Key, Value>>::iterator begin_ptr((std::pair<Key, Value>*)buffer.data);
         uint64_t data_len = buffer.size/record_size;
-        typename std::vector<std::pair<Key, Value>>::iterator end_ptr((std::pair<Key, Value>*)buffer.data+data_len);
         // sort in parallel (uses OpenMP if available, std::thread otherwise)
-        ips4o::parallel::sort(begin_ptr, end_ptr);
+        ips4o::parallel::sort((std::pair<Key, Value>*)buffer.data,
+                              ((std::pair<Key, Value>*)buffer.data)+data_len);
         close_mmap_buffer(&buffer);
         sorted = true;
     }

--- a/src/mmmultiset.hpp
+++ b/src/mmmultiset.hpp
@@ -386,7 +386,7 @@ public:
     private:
         Value* ptr;
         
-        friend class iterator;
+        friend class const_iterator;
     };
     
     /// a local reimplementation of a const pointer iterator


### PR DESCRIPTION
Solution to 2 of 4 compile issues in https://github.com/ekg/mmmultimap/issues/1. Still compiles on ubuntu and appears to pass tests in my hands. 

I got rid of the dependence on `endian.h` (which I'm pretty sure was not actually being used). I also removed all pointer-based constructors for vector iterators by:
1. Giving pointers directly to the `ips4o` methods (pointers actually implement the entire iterator interface)
2. Implementing iterator classes for `mmmulti::set` to return from `begin()` and `end()`