### PR TITLE
Make it compile on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Specify the minimum version for CMake
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.1)
 
 # Project's name
 project(mmmultimap)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Specify the minimum version for CMake
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 # Project's name
 project(mmmultimap)
@@ -11,20 +11,38 @@ set(CMAKE_CXX_STANDARD 14)
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
 
-# Use openmp for parallelism, but it's configured differently on OSX
-find_package(OpenMP)
-if (OPENMP_FOUND)
-  if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -fopenmp")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-  elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # assumes clang build
-    # we can't reliably detect when we're using clang, so for the time being we assume
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -Xpreprocessor -fopenmp")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -Xpreprocessor -fopenmp")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS} -lomp")
-  endif()
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+  # assumes clang build
+  # we can't reliably detect when we're using clang, so for the time being we assume
+  # TODO: can't we though?
+  
+  # adapted from https://stackoverflow.com/questions/46414660/macos-cmake-and-openmp
+  # find_package(OpenMP) does not work reliably on macOS, so we do its work ourselves
+  set (OpenMP_C "${CMAKE_C_COMPILER}")
+  set (OpenMP_C_FLAGS " -Xpreprocessor -fopenmp -I/opt/local/include/libomp -I/usr/local/include -L/opt/local/lib/libomp -L/usr/local/lib")
+  set (OpenMP_C_LIB_NAMES "libomp" "libgomp" "libiomp5")
+  set (OpenMP_CXX "${CMAKE_CXX_COMPILER}")
+  set (OpenMP_CXX_FLAGS " -Xpreprocessor -fopenmp -I/opt/local/include/libomp -I/usr/local/include -L/opt/local/lib/libomp -L/usr/local/lib")
+  set (OpenMP_CXX_LIB_NAMES "libomp" "libgomp" "libiomp5")
+  set (OpenMP_libomp_LIBRARY "omp")
+  set (OpenMP_libgomp_LIBRARY "gomp")
+  set (OpenMP_libiomp5_LIBRARY "iomp5")
+  
+  # and now add the OpenMP parameters to the compile flags
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS} -lomp")
+  
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+
+  find_package(OpenMP REQUIRED)
+  
+  # add the flags it detects to the compile flags
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -fopenmp")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  
 endif()
 
 # Set the output folder where your program will be created
@@ -77,7 +95,7 @@ set(dynamic_INCLUDE "${INSTALL_DIR}/src/dynamic/include")
 # In-place Parallel Super Scalar Samplesort (IPS⁴o), header only
 ExternalProject_Add(ips4o
   GIT_REPOSITORY "https://github.com/vgteam/ips4o.git"
-  GIT_TAG "aac5119bcaf4cedaf3ebb9171f3fc23af4e350d6"
+  GIT_TAG "22069381cc1bf2df07ee1ff47f6b6073fcfb4508"
   UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
@@ -111,13 +129,25 @@ target_include_directories(mmmultimap PUBLIC
   "${dynamic_INCLUDE}"
   "${ips4o_INCLUDE}"
   "${tayweeargs_INCLUDE}")
-target_link_libraries(mmmultimap
-  "${sdsl-lite_LIB}/libsdsl.a"
-  "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
-  "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
-  "-latomic"
-#  "-ltcmalloc_minimal"
-  )
+  
+# macOS doesn't want you to link in libatomic this way
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_libraries(mmmultimap
+    "${sdsl-lite_LIB}/libsdsl.a"
+    "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
+    "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
+  #  "-ltcmalloc_minimal"
+    )
+elseif (TRUE)
+  target_link_libraries(mmmultimap
+    "${sdsl-lite_LIB}/libsdsl.a"
+    "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
+    "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
+    "-latomic"
+  #  "-ltcmalloc_minimal"
+    )
+endif()
+
 
 #set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ltcmalloc")
 


### PR DESCRIPTION
Should finish off https://github.com/ekg/mmmultimap/issues/1

I gotta say, some of my solutions here are less than elegant. The main problem is that `find_package(OpenMP)` just does not seem to work right on Mac (or at least on my Mac), so mostly what I did is replicate what `find_package` is supposed to do manually. There's also a little ugliness based on the fact that Homebrew and MacPorts could have put libomp in different places.

Since OpenMP was already de facto obligatory based on the C++ code, I also went ahead and made it obligatory in the CMakeLists.txt as well. 