### PR TITLE
Use the vgteam fork of SDSL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/vgteam/DYNAMIC.git
 [submodule "deps/sdsl-lite"]
 	path = deps/sdsl-lite
-	url = https://github.com/simongog/sdsl-lite.git
+	url = https://github.com/vgteam/sdsl-lite.git
 [submodule "deps/ips4o"]
 	path = deps/ips4o
 	url = https://github.com/ips4o/ips4o.git


### PR DESCRIPTION
The old SDSL is no longer maintained. VG will switch to the [vgteam fork](https://github.com/vgteam/sdsl-lite) until SDSL 3 is released and we have determined whether we should start using it.